### PR TITLE
Add ignoreStartingPhrase flag to sentence generator

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -73,8 +73,8 @@ export {
   setRandom
 }
 
-export const sentence = () => {
-  const phrase = randomStartingPhrase()
+export const sentence = (ignoreStartingPhrase = false) => {
+  const phrase = ignoreStartingPhrase ? '' : randomStartingPhrase()
   let s = phrase + makeSentenceFromTemplate()
   s = s.charAt(0).toUpperCase() + s.slice(1)
   s += pickLastPunc()

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -18,6 +18,12 @@ describe('Test exported methods', () => {
       expect(val.split(' ').length).toBeGreaterThan(3)
     }
   })
+  test('  test if .sentence() works correctly with ignoreStartingPhrase flag', () => {
+    for (let i = 0; i < LIMIT; i++) {
+      const val = sentence(true)
+      expect(val.split(' ').length).toBeGreaterThan(3)
+    }
+  })
   test('  test if .paragraph() works correctly', () => {
     for (let i = 0; i < LIMIT; i++) {
       const val = paragraph(5)


### PR DESCRIPTION
Note: If we import phrases the test could be better, i.e. making sure there are no complete matches